### PR TITLE
Exit kube-render on first non-zero exit code

### DIFF
--- a/kuberender/file.py
+++ b/kuberender/file.py
@@ -16,17 +16,18 @@ def configure_working_dir(filename, base_config):
     base_config['working-dir'] = dirname
     return base_config
 
+
 def ensure_apply_by_default(parameters):
     if 'should_apply' not in parameters:
         parameters['should_apply'] = True
     return parameters
+
 
 def run(filename, verbose=False):
     content = load_yaml_file(filename)
     base_config = content.get('base', {})
     base_config = configure_working_dir(filename, base_config)
     all_renders = content.get('renders', [])
-    return_codes = set()
     for r in all_renders:
         parameters = merge_dicts([dict(base_config), r])
         parameters = fix_keys(parameters)
@@ -36,5 +37,6 @@ def run(filename, verbose=False):
             sys.stdout.write('\n\n### RENDERING FIRST ###\n')
             sys.stdout.write(str(parameters) + '\n')
         return_code = render.run(**parameters)
-        return_codes.add(return_code)
-    return all(return_codes)
+        if return_code != 0:
+            return return_code
+    return 0

--- a/tests/test_kuberender.py
+++ b/tests/test_kuberender.py
@@ -10,6 +10,11 @@ from kuberender.render import render, run
 
 class KubeRenderTestCase(unittest.TestCase):
 
+    def _pipe_mocK(self, returncode=0):
+        pipe = Mock()
+        pipe.wait.return_value = returncode
+        return pipe
+
     def _partial_render(self, template_folder='test-basic-manifest'):
         return partial(
             render,
@@ -28,13 +33,13 @@ class KubeRenderTestCase(unittest.TestCase):
     def test_applying_multiple_deploy_in_same_file(self, popen_mock):
         context_files = ('base.yaml', 'extended.yaml')
 
-        popen_mock.side_effect = processes = [Mock(), Mock()]
-        run(
+        popen_mock.side_effect = processes = [self._pipe_mocK(), self._pipe_mocK()]
+        assert run(
             template_dir='test-multi-file-manifest',
             should_apply=True,
             context_files=context_files,
             working_dir='tests/resources'
-        )
+        ) == 0
 
         assert popen_mock.call_count == 2
 
@@ -43,6 +48,23 @@ class KubeRenderTestCase(unittest.TestCase):
 
         second_deploy_content = yaml.load(processes[1].communicate.call_args[0][0])
         assert second_deploy_content['metadata']['name'] == 'redis-news-page-cache-2'
+
+    @patch('subprocess.Popen')
+    def test_return_first_non_zero_exit_code_on_failure(self, popen_mock):
+        context_files = ('base.yaml', 'extended.yaml')
+
+        popen_mock.side_effect = processes = [self._pipe_mocK(1), self._pipe_mocK()]
+        assert run(
+            template_dir='test-multi-file-manifest',
+            should_apply=True,
+            context_files=context_files,
+            working_dir='tests/resources'
+        ) == 1
+
+        assert popen_mock.call_count == 1
+
+        first_deploy_content = yaml.load(processes[0].communicate.call_args[0][0])
+        assert first_deploy_content['metadata']['name'] == 'redis-news-page-cache'
 
     def test_merging_context_values(self):
         context_files = ('base.yaml',)

--- a/tests/test_kuberender.py
+++ b/tests/test_kuberender.py
@@ -10,7 +10,7 @@ from kuberender.render import render, run
 
 class KubeRenderTestCase(unittest.TestCase):
 
-    def _pipe_mocK(self, returncode=0):
+    def _pipe_mock(self, returncode=0):
         pipe = Mock()
         pipe.wait.return_value = returncode
         return pipe
@@ -33,7 +33,7 @@ class KubeRenderTestCase(unittest.TestCase):
     def test_applying_multiple_deploy_in_same_file(self, popen_mock):
         context_files = ('base.yaml', 'extended.yaml')
 
-        popen_mock.side_effect = processes = [self._pipe_mocK(), self._pipe_mocK()]
+        popen_mock.side_effect = processes = [self._pipe_mock(), self._pipe_mock()]
         assert run(
             template_dir='test-multi-file-manifest',
             should_apply=True,
@@ -53,7 +53,7 @@ class KubeRenderTestCase(unittest.TestCase):
     def test_return_first_non_zero_exit_code_on_failure(self, popen_mock):
         context_files = ('base.yaml', 'extended.yaml')
 
-        popen_mock.side_effect = processes = [self._pipe_mocK(1), self._pipe_mocK()]
+        popen_mock.side_effect = processes = [self._pipe_mock(1), self._pipe_mock()]
         assert run(
             template_dir='test-multi-file-manifest',
             should_apply=True,

--- a/tests/test_kuberenderfile.py
+++ b/tests/test_kuberenderfile.py
@@ -27,7 +27,34 @@ class KubeRenderFileTestCase(unittest.TestCase):
         ]
 
         # run
-        run('tests/resources/kr-file.yaml')
+        assert run('tests/resources/kr-file.yaml') == 0
         # assert
         assert 2 == run_render.call_count
         run_render.assert_has_calls(expected_calls)
+
+    @patch('kuberender.render.run')
+    def test_run_return_first_non_zero_exit_code(self, run_render):
+        # prepare
+        run_render.return_value = 1
+        expected_calls = [
+            call(
+                context_files=['base.yaml'],
+                overriden_vars={'kind': 'app1'},
+                should_apply=False,
+                template_dir='templates',
+                verbose=True,
+                working_dir='tests/resources'),
+            call(
+                context_files=['base.yaml', 'extended.yaml'],
+                overriden_vars={'kind': 'app2'},
+                should_apply=False,
+                template_dir='templates',
+                verbose=False,
+                working_dir='tests/resources'),
+        ]
+
+        # run
+        assert run('tests/resources/kr-file.yaml') == 1
+        # assert
+        assert 1 == run_render.call_count
+        run_render.assert_has_calls([expected_calls[0]])


### PR DESCRIPTION
Currently kube-render only returns an error exit code (non-zero) if every applied resource fails, this PR changes to exit on the first non-zero return code.