### PR TITLE
Fix kubectl call

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,4 @@ python:
   - "2.7"
   - "3.5"
   - "3.6"
-  - "3.7"
 script: python setup.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,7 @@ language: python
 sudo: false
 python:
   - "2.7"
+  - "3.5"
+  - "3.6"
+  - "3.7"
 script: python setup.py test

--- a/tests/test_kuberender.py
+++ b/tests/test_kuberender.py
@@ -12,6 +12,7 @@ class KubeRenderTestCase(unittest.TestCase):
 
     def _pipe_mock(self, returncode=0):
         pipe = Mock()
+        pipe.communicate.return_value = ('output', None)
         pipe.wait.return_value = returncode
         return pipe
 
@@ -26,6 +27,7 @@ class KubeRenderTestCase(unittest.TestCase):
         )
 
     def _load_template_manifest(self, rendered_templates):
+        rendered_templates = list(rendered_templates)
         assert 1 == len(rendered_templates)
         return yaml.load(rendered_templates[0].content)
 


### PR DESCRIPTION
It wasn't working for Python 2 since version 0.3.1, because of `encoding` parameter.
And never worked for Python 3 because of `rendered_templates` and `yaml.load_all(template.content)` didn't iterate using `map` and didn't raise errors, it silent failed.