### PR TITLE
Fix kubectl call

### DIFF
--- a/kuberender/render.py
+++ b/kuberender/render.py
@@ -30,7 +30,7 @@ def render_templates(template_dir, working_dir, **context):
 
         rendered = template.render(yaml=yaml, **context)
         return RenderedTemplate(filename, rendered)
-    return map(render, filter(should_render_template, os.listdir(template_dir)))
+    return list(map(render, filter(should_render_template, os.listdir(template_dir))))
 
 
 def parse_overriden_vars(overriden_vars):
@@ -88,8 +88,8 @@ def call_kubectl_apply(template):
     def apply_template(content):
         pipe = create_kubectl_apply_pipe()
         str_content = yaml.safe_dump(content, default_flow_style=False, indent=2)
-        output, _ = pipe.communicate(str_content)
-        sys.stdout.write(output)
+        output, _ = pipe.communicate(str_content.encode())
+        sys.stdout.write(output.decode())
         return_code = abs(pipe.wait())
         if return_code != 0:
             raise CalledProcessError(return_code, pipe.args)

--- a/kuberender/render.py
+++ b/kuberender/render.py
@@ -30,7 +30,7 @@ def render_templates(template_dir, working_dir, **context):
 
         rendered = template.render(yaml=yaml, **context)
         return RenderedTemplate(filename, rendered)
-    return list(map(render, filter(should_render_template, os.listdir(template_dir))))
+    return [render(t) for t in os.listdir(template_dir) if should_render_template(t)]
 
 
 def parse_overriden_vars(overriden_vars):

--- a/tests/test_kuberender.py
+++ b/tests/test_kuberender.py
@@ -12,7 +12,7 @@ class KubeRenderTestCase(unittest.TestCase):
 
     def _pipe_mock(self, returncode=0):
         pipe = Mock()
-        pipe.communicate.return_value = ('output', None)
+        pipe.communicate.return_value = (b'output', None)
         pipe.wait.return_value = returncode
         return pipe
 
@@ -27,7 +27,6 @@ class KubeRenderTestCase(unittest.TestCase):
         )
 
     def _load_template_manifest(self, rendered_templates):
-        rendered_templates = list(rendered_templates)
         assert 1 == len(rendered_templates)
         return yaml.load(rendered_templates[0].content)
 


### PR DESCRIPTION
This PR fixes two issues found in the latest version:
- `pipe.communicate` is returning bytes and not string.
- The result of `map` call at the end of the `render` function is not iterable in `for`, converting it to a list fixes this.