### PR TITLE
Add support for passing the name or path of the kubectl executable

### DIFF
--- a/kuberender/__init__.py
+++ b/kuberender/__init__.py
@@ -13,8 +13,9 @@ import click
 @click.option('--working-dir', '-w', default='.', help="Base directory for loading templates and context files")
 @click.option('--generate-files', '-g', 'generate_files', default=False, is_flag=True, help="Generate files for each template")
 @click.option('--generated-dir', '-G', default='./generated', help="Directory for generated templates")
-def cli_render(verbose, template_dir, should_apply, context_files, overriden_vars, template_url, working_dir, generate_files, generated_dir):
-    return_code = render.run(verbose, template_dir, should_apply, context_files, overriden_vars, template_url, working_dir, generate_files, generated_dir)
+@click.option('--kubectl', '-K', default='kubectl', help='name or path to the kubectl executable')
+def cli_render(verbose, template_dir, should_apply, context_files, overriden_vars, template_url, working_dir, generate_files, generated_dir, kubectl):
+    return_code = render.run(verbose, template_dir, should_apply, context_files, overriden_vars, template_url, working_dir, generate_files, generated_dir, kubectl)
     exit(return_code)
 
 


### PR DESCRIPTION
This PR adds a new feature: the hability to specify the `name` or `path` to the `kubectl` executable
![image](https://user-images.githubusercontent.com/34409383/107003514-4e6b2500-6763-11eb-8399-4c91056e4876.png)

This was needed in cloudbuild. Where to use `kubectl` you need to use the script `/builder/kubectl.bash`.
You can say that something like:
```shellscript
mkdir /kubectl_bin
ln -s /builder/kubectl.bash /kubectl_bin/kubectl
export PATH=/kubectl_bin:$PATH
```
Could be used to control the executable without this modification. I tested this running the image locally and it worked, but for some reason the image is broken when used in the google cloud build. After the path modification other commands became unable to be found.